### PR TITLE
ssu: Make sure the ssu cache is up-to-date.

### DIFF
--- a/rpm/ssu.spec
+++ b/rpm/ssu.spec
@@ -196,5 +196,30 @@ fi
 
 %post
 /sbin/ldconfig
-# make sure an old ssud isn't still running
-killall ssud || :
+
+%transfiletriggerin -- %{_datarootdir}/%{name}
+# Touch all modified repo config files so they will be newer than the cache
+grep \.ini$ | xargs -r touch
+%{_bindir}/add-oneshot --now ssu-update-repos
+
+%transfiletriggerun -- %{_datarootdir}/%{name}/features.d/
+if [ "$1" == 0 ]; then
+  echo "Removing ssu feature cache"
+  rm -f /var/cache/ssu/features.ini
+fi
+
+%transfiletriggerun -- %{_datarootdir}/%{name}/board-mappings.d/
+if [ "$1" == 0 ]; then
+  echo "Removing ssu board-mappings cache"
+  rm -f /var/cache/ssu/board-mappings.ini
+fi
+
+%transfiletriggerun -- %{_datarootdir}/%{name}/repos.d/
+if [ "$1" == 0 ]; then
+  echo "Removing ssu main cache"
+  rm -f /var/cache/ssu/repos.ini
+fi
+
+%transfiletriggerpostun -- %{_datarootdir}/%{name}
+%{_bindir}/add-oneshot --now ssu-update-repos
+

--- a/ssu-update-repos
+++ b/ssu-update-repos
@@ -5,5 +5,6 @@ if [ "$MIC_RUN" != "" ]; then
 	exit 1
 fi
 
-touch /usr/share/ssu/board-mappings.d/*.ini 2>/dev/null
+# Update repos
+killall ssud 2>/dev/null || :
 /usr/bin/ssu updaterepos


### PR DESCRIPTION
[ssu] Make sure the ssu cache is up-to-date. Fixes JB#54650

Add RPM file triggers to:
- Touch any new ssu config files so it's newer than the cache
- Remove caches when relevant files are removed.