### PR TITLE
ssu: Don't allow user-added repos to override system repos

### DIFF
--- a/libssu/ssu.h
+++ b/libssu/ssu.h
@@ -47,10 +47,11 @@ public:
      * Filters to control the output of the repository lookup methods
      */
     enum RepoFilter {
-        NoFilter,                 ///< All repositories (global + user)
-        UserFilter,               ///< Only user configured repositories
-        BoardFilter,              ///< Only global repositories, with user blacklist ignored
-        BoardFilterUserBlacklist, ///< Only global repositories, with user blacklist applied
+        UserFilter              = 0x1,              ///< Only user configured repositories
+        BoardFilter             = 0x2,              ///< Only global repositories
+        NoFilter                = 0x3,              ///< All repositories (global | user)
+        UserBlacklist           = 0x4,              ///< User blacklist applied
+        Available               = 0x8,              ///< Include all defined repos, including disabled
     };
 
     /**

--- a/libssu/ssufeaturemanager.cpp
+++ b/libssu/ssufeaturemanager.cpp
@@ -36,25 +36,22 @@ QStringList SsuFeatureManager::repos(bool rndRepo, int filter)
 {
     QStringList r;
 
-    // @TODO features currently can't be blacklisted, but just ignoring user filter
-    // is still the best way atm
-    if (filter == Ssu::UserFilter)
-        return r;
+    if ((filter & Ssu::BoardFilter) == Ssu::BoardFilter) {
+        QString repoHeader = QString("repositories-%1/")
+                             .arg(rndRepo ? "rnd" : "release");
 
-    QString repoHeader = QString("repositories-%1/")
-                         .arg(rndRepo ? "rnd" : "release");
+        // take the global groups
+        featureSettings->beginGroup("repositories");
+        r.append(featureSettings->allKeys());
+        featureSettings->endGroup();
 
-    // take the global groups
-    featureSettings->beginGroup("repositories");
-    r.append(featureSettings->allKeys());
-    featureSettings->endGroup();
+        // and override with rnd/release specific groups
+        featureSettings->beginGroup(repoHeader);
+        r.append(featureSettings->allKeys());
+        featureSettings->endGroup();
 
-    // and override with rnd/release specific groups
-    featureSettings->beginGroup(repoHeader);
-    r.append(featureSettings->allKeys());
-    featureSettings->endGroup();
-
-    r.removeDuplicates();
+        r.removeDuplicates();
+    }
     return r;
 }
 

--- a/libssu/ssurepomanager.h
+++ b/libssu/ssurepomanager.h
@@ -66,18 +66,18 @@ public:
     /**
      * Collect the list of repositories from different submodules
      */
-    QStringList repos(int filter = Ssu::NoFilter);
+    QStringList repos(int filter = Ssu::NoFilter | Ssu::UserBlacklist);
     /**
      * Collect the list of repositories from different submodules.
      * This form allows overriding rnd mode setting.
      */
-    QStringList repos(bool rnd, int filter = Ssu::NoFilter);
+    QStringList repos(bool rnd, int filter = Ssu::NoFilter | Ssu::UserBlacklist);
     /**
      * Collect the list of repositories from different submodules.
      * This form takes a reference to a custom device info instance
      * to allow overrides.
      */
-    QStringList repos(bool rnd, SsuDeviceInfo &deviceInfo, int filter = Ssu::NoFilter);
+    QStringList repos(bool rnd, SsuDeviceInfo &deviceInfo, int filter = Ssu::NoFilter | Ssu::UserBlacklist);
     /**
      * Resolve repository specific variables, and store them in storageHash. Does
      * not include adaptation specific variables, see SsuDeviceInfo::adaptationVariables

--- a/tests/ut_repomanager/repomanagertest.cpp
+++ b/tests/ut_repomanager/repomanagertest.cpp
@@ -37,22 +37,18 @@ void RepoManagerTest::testSettings()
 
     repoManager.add("repo1");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
 
     repoManager.disable("repo1");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(coreConfig->value("disabled-repos").toStringList().contains("repo1"));
 
     repoManager.enable("repo1");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
 
     repoManager.add("repo2", "http://repo2");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
     QCOMPARE(coreConfig->value("repository-urls/repo2").toString(), QString("http://repo2"));
     QVERIFY(!coreConfig->value("enabled-repos").toStringList().contains("repo2"));
@@ -60,7 +56,6 @@ void RepoManagerTest::testSettings()
 
     repoManager.disable("repo2");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
     QCOMPARE(coreConfig->value("repository-urls/repo2").toString(), QString("http://repo2"));
     QVERIFY(!coreConfig->value("enabled-repos").toStringList().contains("repo2"));
@@ -68,7 +63,6 @@ void RepoManagerTest::testSettings()
 
     repoManager.enable("repo2");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
     QCOMPARE(coreConfig->value("repository-urls/repo2").toString(), QString("http://repo2"));
     QVERIFY(!coreConfig->value("enabled-repos").toStringList().contains("repo2"));
@@ -76,10 +70,8 @@ void RepoManagerTest::testSettings()
 
     repoManager.add("repo2");
     QCOMPARE(coreConfig->value("repository-urls/repo1").toString(), QString("http://repo1"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
     QCOMPARE(coreConfig->value("repository-urls/repo2").toString(), QString("http://repo2"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo2"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo2"));
 
     repoManager.remove("repo1");
@@ -87,7 +79,6 @@ void RepoManagerTest::testSettings()
     QVERIFY(!coreConfig->value("enabled-repos").toStringList().contains("repo1"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo1"));
     QCOMPARE(coreConfig->value("repository-urls/repo2").toString(), QString("http://repo2"));
-    QVERIFY(coreConfig->value("enabled-repos").toStringList().contains("repo2"));
     QVERIFY(!coreConfig->value("disabled-repos").toStringList().contains("repo2"));
 
     repoManager.remove("repo2");

--- a/tests/ut_repomanager/testdata/repos.ini
+++ b/tests/ut_repomanager/testdata/repos.ini
@@ -2,11 +2,11 @@
 credentials=vendor
 credentials-url=https://%(ssuRegDomain)/%(ssuRegPath)/%1/credentials.xml
 register-url=https://%(ssuRegDomain)/%(ssuRegPath)/%1/register.xml
-store=https://%(packagesDomain)/store/
 
 [release]
 vendor=https://%(packagesDomain)/releases/%(release)/vendor/%(arch)/
 apps=https://%(packagesDomain)/releases/%(release)/vendor-apps/%(arch)/
+store=https://%(packagesDomain)/store/
 
 [rnd]
 mer-core=https://%(packagesDomain)/mer/%(release)/builds/%(arch)/%(debugSplit)/
@@ -14,6 +14,7 @@ adaptation=https://%(packagesDomain)/nemo/%(release)/adaptation-%(deviceFamily)/
 nemo=https://%(packagesDomain)/nemo/%(release)/platform/%(arch)/
 non-oss=https://%(dumpDomain)/pj:/non-oss%(flavour)/%(release)_%(arch)/
 oss=https://%(dumpDomain)/pj:/oss%(flavour)/%(release)_%(arch)/
+store=https://%(packagesDomain)/store/
 
 [devel-flavour]
 flavour-pattern=


### PR DESCRIPTION
[ssu] Don't allow user-added repos to override system repos. Fixes JB#57866

- Give a warning and fail if a system repo name is added with a URL
- Give a warning and fail if a non-existent system repo name is added
without a URL
- Resolve system repos first, and only check for user repos if the name
isn't found.