### PR TITLE
[ssu] Migrate final qSort to std::sort. JB#59963

### DIFF
--- a/libssu/ssufeaturemodel.cpp
+++ b/libssu/ssufeaturemodel.cpp
@@ -58,7 +58,7 @@ public:
                 settings.endGroup();
             }
         }
-        qSort(features.begin(), features.end(), featureLessThan);
+        std::sort(features.begin(), features.end(), featureLessThan);
     }
 
     QString path;

--- a/rpm/ssu.spec
+++ b/rpm/ssu.spec
@@ -4,7 +4,7 @@ Release: 1
 Summary: Seamless Software Upgrade
 License: GPLv2+ and LGPLv2+ and BSD
 Source0: %{name}-%{version}.tar.gz
-URL: https://git.sailfishos.org/mer-core/ssu
+URL: https://github.com/sailfishos/ssu
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5DBus)
 BuildRequires: pkgconfig(Qt5Network)


### PR DESCRIPTION
Also fixed the .spec url to the current one.