### PR TITLE
Add major and minor release versions in repo variables

### DIFF
--- a/libssu/ssurepomanager.cpp
+++ b/libssu/ssurepomanager.cpp
@@ -378,6 +378,7 @@ QStringList SsuRepoManager::repoVariables(QHash<QString, QString> *storageHash, 
     SsuCoreConfig *settings = SsuCoreConfig::instance();
     QStringList configSections;
     SsuSettings repoSettings(SSU_REPO_CONFIGURATION, SSU_REPO_CONFIGURATION_DIR);
+    QString release = settings->release(rnd);
 
     // fill in all arbitrary repo specific variables from ssu.ini
     var.variableSection(settings, "repository-url-variables", storageHash);
@@ -406,7 +407,10 @@ QStringList SsuRepoManager::repoVariables(QHash<QString, QString> *storageHash, 
         configSections << "release" << "all";
     }
 
-    storageHash->insert("release", settings->release(rnd));
+    storageHash->insert("release", release);
+    storageHash->insert("releaseMajor", release.section('.', 0, 0));
+    storageHash->insert("releaseMinor", release.section('.', 1, 1));
+    storageHash->insert("releaseMajorMinor", release.section('.', 0, 1));
 
     if (!storageHash->contains("debugSplit"))
         storageHash->insert("debugSplit", "packages");

--- a/tests/ut_urlresolver/testdata/repos.ini
+++ b/tests/ut_urlresolver/testdata/repos.ini
@@ -10,6 +10,9 @@ mer-core=https://%(packagesDomain)/%(release)/mer/%(arch)/%(debugSplit)/
 adaptation-common-main=https://%(packagesDomain)/releases/%(release)/nemo/adaptation-%(deviceFamily)-common/%(arch)/
 adaptation=https://%(packagesDomain)/releases/%(release)/nemo/adaptation-%(adaptation)/%(arch)/
 nemo=https://%(packagesDomain)/releases/%(release)/nemo/platform/%(arch)/
+major=https://%(packagesDomain)/releases/%(releaseMajor)/major/%(arch)/
+minor=https://%(packagesDomain)/releases/%(releaseMinor)/minor/%(arch)/
+majmin=https://%(packagesDomain)/releases/%(releaseMajorMinor)/majmin/%(arch)/
 
 [rnd]
 mer-core=https://%(packagesDomain)/mer/%(release)/builds/%(arch)/%(debugSplit)/

--- a/tests/ut_urlresolver/urlresolvertest.cpp
+++ b/tests/ut_urlresolver/urlresolvertest.cpp
@@ -28,9 +28,12 @@ void UrlResolverTest::initTestCase()
     /*
       rndRepos["non-oss"] = "";
     */
-    releaseRepos["nemo"] = QString("https://packages.example.com/releases/0.1/nemo/platform/%1/").arg(arch);
-    releaseRepos["mer-core"] = QString("https://packages.example.com/0.1/mer/%1/packages/").arg(arch);
-    releaseRepos["jolla"] = QString("https://packages.example.com/releases/0.1/jolla/%1/").arg(arch);
+    releaseRepos["nemo"] = QString("https://packages.example.com/releases/1.2.3/nemo/platform/%1/").arg(arch);
+    releaseRepos["mer-core"] = QString("https://packages.example.com/1.2.3/mer/%1/packages/").arg(arch);
+    releaseRepos["jolla"] = QString("https://packages.example.com/releases/1.2.3/jolla/%1/").arg(arch);
+    releaseRepos["major"] = QString("https://packages.example.com/releases/1/major/%1/").arg(arch);
+    releaseRepos["minor"] = QString("https://packages.example.com/releases/2/minor/%1/").arg(arch);
+    releaseRepos["majmin"] = QString("https://packages.example.com/releases/1.2/majmin/%1/").arg(arch);
 }
 
 void UrlResolverTest::cleanupTestCase()
@@ -115,6 +118,7 @@ void UrlResolverTest::simpleRepoUrlLookup()
 
 void UrlResolverTest::checkReleaseRepoUrls()
 {
+    ssu.setRelease("1.2.3");
     QHashIterator<QString, QString> i(releaseRepos);
     while (i.hasNext()) {
         QString url;


### PR DESCRIPTION
Allows using `%(releaseMajor)`, `%(releaseMinor)`, and `%(releaseMajorMinor)` in the repository URL, which, for example, with release 4.6.0.x will be interpolated to 4, 6, and 4.6 respectively.