### PR TITLE
More robust repo data

### DIFF
--- a/libssu/ssurepomanager.cpp
+++ b/libssu/ssurepomanager.cpp
@@ -25,6 +25,7 @@
 #include <QStringList>
 #include <QRegExp>
 #include <QDirIterator>
+#include <QSaveFile>
 
 #include <zypp/RepoManager.h>
 #include <zypp/RepoInfo.h>
@@ -359,7 +360,7 @@ void SsuRepoManager::update()
             continue;
         }
 
-        QFile repoFile(repoFilePath);
+        QSaveFile repoFile(repoFilePath);
 
         if (repoFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
             QTextStream out(&repoFile);
@@ -378,6 +379,9 @@ void SsuRepoManager::update()
                 out << "baseurl=plugin:ssu?repo=" << repoName << debugSplit << endl;
 
             out.flush();
+            if (!repoFile.commit()) {
+                SsuLog::print(LOG_ERR, QString::fromLatin1("Error committing repo file for ") + repo);
+            }
         }
     }
 }


### PR DESCRIPTION
Main commit

    [ssu] Protect malformed repo data by creating them with QSaveFile. JB#62842
    
    Seems like there's some race condition with usage of SsuRepoManager and
    PackageKit zypper backend for adjusting repo status, with some chance
    of having a repo file with a non-parseable mixture of both.
    
    There's possibly a race condition elsewhere if that can happen, but
    let's at least avoid writing garbled content here by using a temporary
    file that gets renamed atomically.

