### PR TITLE
Make device id source configurable. Fixes JB#38016

### DIFF
--- a/examples/board-mappings.ini
+++ b/examples/board-mappings.ini
@@ -101,6 +101,7 @@ family=n900
 adaptation-repos=n9xx-common,n900
 
 [SDK]
+device-id-source=machine-id
 
 [generic-x86]
 family=x86

--- a/libssu/ssudeviceinfo.cpp
+++ b/libssu/ssudeviceinfo.cpp
@@ -316,36 +316,70 @@ normalizeUid(const QString &uid)
     return uid.trimmed().replace(":", "").replace("-", "").toLower();
 }
 
+SsuDeviceIdSource SsuDeviceInfo::deviceIdSource()
+{
+    SsuDeviceIdSource source;
+
+    QString configValue =
+        boardMappings->value(deviceVariant(true) + "/device-id-source", "any").toString();
+    
+    if (!configValue.compare("imei")) {
+        source.imei = true;
+    } else if (!configValue.compare("wlan-mac")) {
+        source.wlanMac = true;
+    } else if (!configValue.compare("machine-id")) {
+        source.machineId = true;
+    } else {
+        if (!configValue.isEmpty() && configValue.compare("any")) {
+            SsuLog::print(LOG_WARNING, "Invalid device id configuration, allowing all sources");
+        }
+        source.imei = true;
+        source.wlanMac = true;
+        source.machineId = true;
+    }
+
+    return source;
+}
+
 QString SsuDeviceInfo::deviceUid()
 {
-    QStringList imeis = ofonoGetImeis();
-    if (imeis.size() > 0) {
-        return imeis[0];
-    }
+    SsuDeviceIdSource source = deviceIdSource();
 
-    QStringList wlanMacs = getWlanMacs();
-    if (wlanMacs.size() > 0) {
-        return normalizeUid(wlanMacs[0]);
-    }
-
-    SsuLog::print(LOG_WARNING, "Could not get IMEI(s) from ofono, nor WLAN mac, trying fallback");
-
-    // The fallback list is taken from QtSystems' qdeviceinfo_linux.cpp
-    QStringList fallbackFiles;
-    fallbackFiles << "/sys/devices/virtual/dmi/id/product_uuid";
-    fallbackFiles << "/etc/machine-id";
-    fallbackFiles << "/etc/unique-id";
-    fallbackFiles << "/var/lib/dbus/machine-id";
-
-    foreach (const QString &filename, fallbackFiles) {
-        QFile machineId(filename);
-        if (machineId.open(QFile::ReadOnly | QFile::Text) && machineId.size() > 0) {
-            QTextStream in(&machineId);
-            return normalizeUid(in.readAll());
+    if (source.imei) {
+        QStringList imeis = ofonoGetImeis();
+        if (imeis.size() > 0) {
+            return imeis[0];
         }
+        SsuLog::print(LOG_WARNING, "Could not get IMEI");
+    }
+    
+    if (source.wlanMac) {
+        QStringList wlanMacs = getWlanMacs();
+        if (wlanMacs.size() > 0) {
+            return normalizeUid(wlanMacs[0]);
+        }
+        SsuLog::print(LOG_WARNING, "Could not get WLAN MAC");
     }
 
-    SsuLog::print(LOG_CRIT, "Could not read fallback UID - returning empty string");
+    if (source.machineId) {
+        // The fallback list is taken from QtSystems' qdeviceinfo_linux.cpp
+        QStringList fallbackFiles;
+        fallbackFiles << "/sys/devices/virtual/dmi/id/product_uuid";
+        fallbackFiles << "/etc/machine-id";
+        fallbackFiles << "/etc/unique-id";
+        fallbackFiles << "/var/lib/dbus/machine-id";
+    
+        foreach (const QString &filename, fallbackFiles) {
+            QFile machineId(filename);
+            if (machineId.open(QFile::ReadOnly | QFile::Text) && machineId.size() > 0) {
+                QTextStream in(&machineId);
+                return normalizeUid(in.readAll());
+            }
+        }
+        SsuLog::print(LOG_CRIT, "Could not get machine id");
+    }
+    
+    SsuLog::print(LOG_CRIT, "Returning empty device id");
     return QString();
 }
 

--- a/libssu/ssudeviceinfo.h
+++ b/libssu/ssudeviceinfo.h
@@ -12,6 +12,38 @@
 
 #include "ssu.h"
 
+/**
+ * Represents the currently allowed sources for determening the device id.
+ * Unset configuration enables all sources to maintain backwards compatibility.
+ *
+ * The board mapping configuration key is "device-id-source" which defaults to value "any".
+ */
+struct SsuDeviceIdSource {
+    /**
+     * Allow using the IMEI code, if any, as basis of device id. Configuration value: "imei"
+     */
+
+    bool imei = false;
+    /**
+     * Allow using the WLAN adapter MAC address, if any, as basis of device id. Configuration value: "wlan-mac"
+     */
+
+    bool wlanMac = false;
+    /**
+     * Allow using the machine-id, as basis of device id. Configuration value: "machine-id"
+     *
+     * There are several locations where the read is attempted,
+     * see the source code of SsuDeviceInfo::deviceUid for details.
+     */
+    bool machineId = false;
+};
+
+inline bool operator==(SsuDeviceIdSource lhs, SsuDeviceIdSource rhs) {
+    return lhs.imei == rhs.imei
+        && lhs.wlanMac == rhs.wlanMac
+        && lhs.machineId == rhs.machineId;
+}
+
 class SsuSettings;
 
 class SsuDeviceInfo: public QObject
@@ -66,8 +98,17 @@ public:
     Q_INVOKABLE QString deviceModel();
 
     /**
-     * Calculate the device ID used in ssu requests
-     * @return The first imei from oFono ModemManager API, if available, or WLAN mac address, or device uid fallback code similar to QDeviceInfo::uniqueDeviceID()
+     * Read the board mapping configuration and determine the allowed source, or sources, of device id.
+     *
+     * The configuration can either allow a single source, or all/any sources at once.
+     */
+    SsuDeviceIdSource deviceIdSource();
+
+    /**
+     * Calculate the device ID used in ssu requests, according to board mapping configuration, if any.
+     * Without any configuration, return the first imei from oFono ModemManager API, or WLAN mac address,
+     * or device uid fallback code similar to QDeviceInfo::uniqueDeviceID().
+     * @return The device id string
      */
     Q_INVOKABLE QString deviceUid();
 

--- a/rpm/ssu.spec
+++ b/rpm/ssu.spec
@@ -1,5 +1,5 @@
 Name: ssu
-Version: 1.6.1
+Version: 1.6.5
 Release: 1
 Summary: Seamless Software Upgrade
 License: GPLv2+ and LGPLv2+ and BSD

--- a/tests/ut_deviceinfo/deviceinfotest.cpp
+++ b/tests/ut_deviceinfo/deviceinfotest.cpp
@@ -22,6 +22,7 @@ private slots:
     void testAdaptationVariables();
     void testFeatureVariables();
     void testDeviceUid();
+    void testDeviceIdSource();
     void testVariableSection();
     void testValue();
 
@@ -73,6 +74,71 @@ void DeviceInfoTest::testFeatureVariables()
 void DeviceInfoTest::testDeviceUid()
 {
     QVERIFY2(!SsuDeviceInfo().deviceUid().isEmpty(), "No method to get device UID on this platform");
+}
+
+
+void DeviceInfoTest::testDeviceIdSource()
+{
+    {
+        SsuDeviceInfo deviceInfo("id-empty");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = true;
+        expected.wlanMac = true;
+        expected.machineId = true;
+        QCOMPARE(actual, expected);
+    }
+    {
+        SsuDeviceInfo deviceInfo("id-any");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = true;
+        expected.wlanMac = true;
+        expected.machineId = true;
+        QCOMPARE(actual, expected);
+    }
+    {
+        SsuDeviceInfo deviceInfo("id-invalid");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = true;
+        expected.wlanMac = true;
+        expected.machineId = true;
+        QCOMPARE(actual, expected);
+    }
+    {
+        SsuDeviceInfo deviceInfo("id-imei");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = true;
+        expected.wlanMac = false;
+        expected.machineId = false;
+        QCOMPARE(actual, expected);
+    }
+    {
+        SsuDeviceInfo deviceInfo("id-wlan");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = false;
+        expected.wlanMac = true;
+        expected.machineId = false;
+        QCOMPARE(actual, expected);
+    }
+    {
+        SsuDeviceInfo deviceInfo("id-system");
+        SsuDeviceIdSource actual, expected;
+        
+        actual = deviceInfo.deviceIdSource();
+        expected.imei = false;
+        expected.wlanMac = false;
+        expected.machineId = true;
+        QCOMPARE(actual, expected);
+    }
 }
 
 void DeviceInfoTest::testVariableSection()

--- a/tests/ut_deviceinfo/testdata/board-mappings.ini
+++ b/tests/ut_deviceinfo/testdata/board-mappings.ini
@@ -54,3 +54,19 @@ variables = foo, bar
 [var-N9-feature1]
 feature=test
 
+[id-empty]
+
+[id-any]
+device-id-source=any
+
+[id-invalid]
+device-id-source=foobar
+
+[id-imei]
+device-id-source=imei
+
+[id-wlan]
+device-id-source=wlan-mac
+
+[id-system]
+device-id-source=machine-id


### PR DESCRIPTION
Makes it possible to ensure a single device id source is used. With configuration added elsewhere, this fixes Platform SDK repeatedly needing `ssu register` when refreshing repos or installing packages.